### PR TITLE
Install ntpdate on Debian

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,3 +1,6 @@
 ---
-- name: Install the required packages in Debian derivatives
+- name: install the required packages in debian derivatives
   apt: name=ntp update_cache=yes
+
+- name: install ntpdate in debian derivatives
+  apt: name=ntpdate update_cache=yes


### PR DESCRIPTION
On Ubuntu 16.04 the ntpdate task fails as ntpdate package is not installed.